### PR TITLE
Add 2D molecule data endpoint

### DIFF
--- a/api/agent_management/agents/pubchem_agent.py
+++ b/api/agent_management/agents/pubchem_agent.py
@@ -719,6 +719,86 @@ Only respond with the molecule name or 'N/A', no other text.""",
             # For advanced usage, see self.get_compound_details
         }
 
+    def get_molecule_2d_info(self, user_query: str) -> Dict[str, Any]:
+        """Fetch 2D structural information for a molecule.
+
+        This is similar to :meth:`get_molecule_data` but instead of returning a
+        PDB block intended for 3D visualization it provides atomic coordinates
+        in two dimensions for drawing a 2D diagram.
+
+        Args:
+            user_query: User supplied text describing the molecule.
+
+        Returns:
+            Dictionary with keys ``atoms`` and ``bonds`` containing 2D
+            coordinates and connectivity information as well as ``name``,
+            ``cid`` and ``formula``.
+        """
+
+        self.logger.info(f"[DEBUG] Fetching 2D molecule info for: {user_query}")
+
+        molecule_name = self.interpret_user_query(user_query)
+        if not molecule_name:
+            raise ValueError("Could not interpret user query into a molecule name.")
+
+        compounds = self._search_with_fallbacks(molecule_name)
+        if not compounds:
+            raise ValueError(f"No compounds found for {molecule_name}")
+
+        compound = compounds[0]
+        cid = compound.cid if hasattr(compound, "cid") else compound.get("cid")
+        if not cid:
+            raise ValueError("Compound has no valid CID.")
+
+        sdf_url = f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{cid}/SDF"
+        response = requests.get(sdf_url, timeout=30)
+        if response.status_code != 200:
+            raise ValueError(f"Failed to get 2D SDF for CID {cid}")
+
+        sdf_data = response.text
+
+        mol = Chem.MolFromMolBlock(sdf_data, sanitize=True, removeHs=False)
+        if mol is None:
+            raise ValueError("Unable to parse SDF data")
+
+        if mol.GetNumConformers() == 0:
+            AllChem.Compute2DCoords(mol)
+
+        conf = mol.GetConformer()
+        atoms = []
+        for atom in mol.GetAtoms():
+            pos = conf.GetAtomPosition(atom.GetIdx())
+            atoms.append({
+                "element": atom.GetSymbol(),
+                "x": pos.x,
+                "y": pos.y,
+            })
+
+        bonds = []
+        for bond in mol.GetBonds():
+            bonds.append({
+                "start": bond.GetBeginAtomIdx(),
+                "end": bond.GetEndAtomIdx(),
+                "order": bond.GetBondTypeAsDouble(),
+            })
+
+        name = (
+            compound.iupac_name if hasattr(compound, "iupac_name")
+            else compound.get("iupac_name", str(cid))
+        )
+        formula = (
+            compound.molecular_formula if hasattr(compound, "molecular_formula")
+            else compound.get("formula", "")
+        )
+
+        return {
+            "atoms": atoms,
+            "bonds": bonds,
+            "name": name,
+            "cid": cid,
+            "formula": formula,
+        }
+
     def generate_visualization(self, molecule_data: Dict[str, Any]) -> str:
         """
         Step B:

--- a/api/routers/prompt/routes.py
+++ b/api/routers/prompt/routes.py
@@ -907,6 +907,22 @@ async def fetch_molecule_data(request: FetchMoleculeRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.post("/fetch-molecule-2d/")
+async def fetch_molecule_2d_data(request: FetchMoleculeRequest):
+    """Return 2D coordinate information for a molecule."""
+    try:
+        pubchem_agent = AgentFactory.create_pubchem_agent(
+            script_model=None,
+            use_element_labels=True,
+            convert_back_to_indices=True,
+        )
+        data = pubchem_agent.get_molecule_2d_info(request.query)
+        return data
+    except Exception as e:
+        logger.error(f"Error in fetch_molecule_2d_data: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.post("/generate-molecule-html/")
 async def generate_molecule_html(request: GenerateHTMLRequest):
     """

--- a/api/tests/test_molecule_2d.py
+++ b/api/tests/test_molecule_2d.py
@@ -1,0 +1,56 @@
+import json
+from types import SimpleNamespace
+import requests
+import pytest
+
+from agent_management.agents.pubchem_agent import PubChemAgent
+from agent_management.llm_service import LLMService, LLMModelConfig, ProviderType
+
+
+def make_agent():
+    config = LLMModelConfig(provider=ProviderType.OPENAI, model_name="gpt-3.5-turbo")
+    llm_service = LLMService(config)
+    return PubChemAgent(llm_service)
+
+
+@pytest.fixture()
+def sample_sdf():
+    path = "api/compound_data/cid_4140276/compound_details.json"
+    with open(path) as f:
+        data = json.load(f)
+    return data["structure"]["sdf_2d"]
+
+
+def test_get_molecule_2d_info(monkeypatch, sample_sdf):
+    agent = make_agent()
+
+    class FakeCompound(SimpleNamespace):
+        pass
+
+    fake_compound = FakeCompound(
+        cid=4140276,
+        iupac_name="Water",
+        molecular_formula="H2O",
+    )
+
+    def fake_interpret(query: str):
+        return "water"
+
+    def fake_search(query: str):
+        return [fake_compound]
+
+    class FakeResponse:
+        status_code = 200
+        text = sample_sdf
+
+    def fake_get(url, timeout=30):
+        return FakeResponse()
+
+    monkeypatch.setattr(agent, "interpret_user_query", fake_interpret)
+    monkeypatch.setattr(agent, "_search_with_fallbacks", fake_search)
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = agent.get_molecule_2d_info("water")
+    assert result["cid"] == 4140276
+    assert len(result["atoms"]) > 0
+    assert len(result["bonds"]) > 0


### PR DESCRIPTION
## Summary
- provide PubChemAgent method to fetch 2D coordinate info
- expose new `/fetch-molecule-2d/` API endpoint
- add regression test for 2D data method

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*